### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/acherlyonok/835dceeb-f24f-4fb5-8420-f19f503b6904/dff36aaf-6df7-4871-bb9a-9569e70af1ef/_apis/work/boardbadge/60184a95-42b0-4577-93a5-652b8ac42c6c)](https://dev.azure.com/acherlyonok/835dceeb-f24f-4fb5-8420-f19f503b6904/_boards/board/t/dff36aaf-6df7-4871-bb9a-9569e70af1ef/Microsoft.RequirementCategory)
 ### Ansible
 
 ### Version


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/acherlyonok/835dceeb-f24f-4fb5-8420-f19f503b6904/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.